### PR TITLE
Add limit of before php 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.3,<5.5",
         "ircmaxell/password-compat": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Add limit of before php 5.5 - so that the package does not install on systems that do not require it.