### PR TITLE
Use correct block size for SHA1

### DIFF
--- a/Php55.php
+++ b/Php55.php
@@ -43,6 +43,7 @@ final class Php55
         // Pre-hash for optimization if password length > hash length
         $hashLength = \strlen(hash($algorithm, '', true));
         switch ($algorithm) {
+            case 'sha1':
             case 'sha224':
             case 'sha256':
                 $blockSize = 64;


### PR DESCRIPTION
SHA1 has a 64 byte (512 bit) block size, not a 20 byte (160 bit) block size like you would expect.

Tests:
```php
<?php
use Symfony\Polyfill\Php55\Php55;
require "polyfill.php";

foreach ([
    str_repeat('A', 63),
    str_repeat('A', 64),
    str_repeat('A', 65),
] as $s) {
    $x = hash_pbkdf2('sha1', $s, $s, 4096, 25);
    $y = Php55::hash_pbkdf2('sha1', $s, $s, 4096, 25);
    if (!hash_equals($x, $y)) {
         var_dump($x, $y);
         exit(1);
    }
}
```